### PR TITLE
Fix login/register JSON output

### DIFF
--- a/backend/buy-ticket.php
+++ b/backend/buy-ticket.php
@@ -1,7 +1,7 @@
 <?php
 // Enable error reporting for debugging
 error_reporting(E_ALL);
-ini_set('display_errors', 1);
+ini_set('display_errors', 0);
 
 // For CORS - allow cross-origin requests
 header('Access-Control-Allow-Origin: http://localhost');

--- a/backend/create-ticket.php
+++ b/backend/create-ticket.php
@@ -1,7 +1,7 @@
 <?php
 // Enable error reporting for debugging
 error_reporting(E_ALL);
-ini_set('display_errors', 1);
+ini_set('display_errors', 0);
 
 // For CORS - allow cross-origin requests
 header('Access-Control-Allow-Origin: http://localhost');

--- a/backend/db_connection.php
+++ b/backend/db_connection.php
@@ -1,7 +1,7 @@
 <?php
 // Enable error reporting for debugging
 error_reporting(E_ALL);
-ini_set('display_errors', 1);
+ini_set('display_errors', 0);
 
 // Database configuration
 $db_host = "pzquwmxgtrbfoiyvclkhsnda.duckdns.org";

--- a/backend/delete-ticket.php
+++ b/backend/delete-ticket.php
@@ -1,7 +1,7 @@
 <?php
 // Enable error reporting for debugging
 error_reporting(E_ALL);
-ini_set('display_errors', 1);
+ini_set('display_errors', 0);
 
 // For CORS - allow cross-origin requests
 header('Access-Control-Allow-Origin: *');

--- a/backend/get-tickets.php
+++ b/backend/get-tickets.php
@@ -1,7 +1,7 @@
 <?php
 // Enable error reporting for debugging
 error_reporting(E_ALL);
-ini_set('display_errors', 1);
+ini_set('display_errors', 0);
 
 // For CORS - allow cross-origin requests
 header('Access-Control-Allow-Origin: *');

--- a/backend/login.php
+++ b/backend/login.php
@@ -1,7 +1,7 @@
 <?php
 // Enable error reporting for debugging
 error_reporting(E_ALL);
-ini_set('display_errors', 1);
+ini_set('display_errors', 0);
 
 // Set proper CORS headers for handling credentials
 header('Access-Control-Allow-Origin: http://localhost');  // Use your actual domain in production

--- a/backend/logout.php
+++ b/backend/logout.php
@@ -1,7 +1,7 @@
 <?php
 // Enable error reporting for debugging
 error_reporting(E_ALL);
-ini_set('display_errors', 1);
+ini_set('display_errors', 0);
 
 // For CORS - allow cross-origin requests
 header('Access-Control-Allow-Origin: *');

--- a/backend/manage-balance.php
+++ b/backend/manage-balance.php
@@ -1,7 +1,7 @@
 <?php
 // Enable error reporting for debugging
 error_reporting(E_ALL);
-ini_set('display_errors', 1);
+ini_set('display_errors', 0);
 
 // Set content type to JSON
 header('Content-Type: application/json');

--- a/backend/manage-favorites.php
+++ b/backend/manage-favorites.php
@@ -1,6 +1,6 @@
 <?php
 error_reporting(E_ALL);
-ini_set('display_errors', 1);
+ini_set('display_errors', 0);
 
 header('Access-Control-Allow-Origin: http://localhost');
 header('Access-Control-Allow-Methods: POST, GET, OPTIONS');

--- a/backend/rate_limiter.php
+++ b/backend/rate_limiter.php
@@ -2,7 +2,9 @@
 // Rate limiting functionality to prevent brute force attacks
 
 function checkRateLimit($identifier, $maxAttempts = 5, $timeWindow = 900) { // 15 minutes
-    session_start();
+    if (session_status() === PHP_SESSION_NONE) {
+        session_start();
+    }
     
     $currentTime = time();
     $rateLimitKey = 'rate_limit_' . $identifier;
@@ -53,7 +55,9 @@ function checkRateLimit($identifier, $maxAttempts = 5, $timeWindow = 900) { // 1
 }
 
 function recordFailedAttempt($identifier) {
-    session_start();
+    if (session_status() === PHP_SESSION_NONE) {
+        session_start();
+    }
     
     $rateLimitKey = 'rate_limit_' . $identifier;
     
@@ -69,7 +73,9 @@ function recordFailedAttempt($identifier) {
 }
 
 function resetRateLimit($identifier) {
-    session_start();
+    if (session_status() === PHP_SESSION_NONE) {
+        session_start();
+    }
     
     $rateLimitKey = 'rate_limit_' . $identifier;
     unset($_SESSION[$rateLimitKey]);

--- a/backend/register.php
+++ b/backend/register.php
@@ -1,7 +1,7 @@
 <?php
 // Enable error reporting for debugging
 error_reporting(E_ALL);
-ini_set('display_errors', 1);
+ini_set('display_errors', 0);
 
 // For CORS - allow cross-origin requests
 header('Access-Control-Allow-Origin: *');

--- a/backend/session.php
+++ b/backend/session.php
@@ -1,7 +1,7 @@
 <?php
 // Enable error reporting for debugging
 error_reporting(E_ALL);
-ini_set('display_errors', 1);
+ini_set('display_errors', 0);
 
 // Set proper CORS headers for handling credentials only if this is the main script
 if (!isset($INCLUDED_FROM_OTHER_SCRIPT)) {

--- a/register.html
+++ b/register.html
@@ -370,14 +370,6 @@
                     // Log what we're sending
                     console.log("Sending form data:", Object.fromEntries(formData));
                     
-                    // Try getting a simple file first to test server connection
-                    try {
-                        const testResponse = await fetch('backend/test-db.php');
-                        const testText = await testResponse.text();
-                        console.log("Server connection test:", testText);
-                    } catch (testError) {
-                        console.error("Server connection test failed:", testError);
-                    }
                     
                     // Send registration request
                     const response = await fetch('backend/register.php', {


### PR DESCRIPTION
## Summary
- avoid duplicate session_start warnings in rate limiter
- remove connection test that used missing test-db.php
- disable PHP display_errors across backend to keep responses JSON

## Testing
- `php -l backend/login.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683ffbe0f3d4833197c3114b9fcc4b04